### PR TITLE
📦 Add a missing runtime dependency on flake8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,9 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = []
+dependencies = [
+  "flake8 >= 5",
+]
 dynamic = ["version"]
 
 [project.entry-points."flake8.extension"]


### PR DESCRIPTION
The lower bound is v5 because it tracebacks on anything older. At least in that one virtualenv I used for testing. Maybe, there's more to it but I didn't bother looking deeper.